### PR TITLE
Implement Android onTrimMemory bridge and integrate with Starboard allocator

### DIFF
--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -18,6 +18,12 @@ if (is_ios) {
   import("//build/config/apple/mobile_config.gni")
 }
 
+declare_args() {
+  # Enables the memory pressure bridge that forwards Chromium memory pressure
+  # signals to Starboard allocators.
+  enable_memory_pressure_bridge = true
+}
+
 source_set("browser") {
   sources = [
     "captured_surface_controller_stub.cc",
@@ -34,6 +40,14 @@ source_set("browser") {
     "h5vcc_settings_impl.cc",
     "h5vcc_settings_impl.h",
   ]
+
+  if (enable_memory_pressure_bridge) {
+    defines = [ "ENABLE_MEMORY_PRESSURE_BRIDGE" ]
+    sources += [
+      "memory_pressure_bridge.cc",
+      "memory_pressure_bridge.h",
+    ]
+  }
 
   if (is_androidtv) {
     sources += [

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -47,6 +47,10 @@
 #include "cobalt/browser/cobalt_content_browser_client.h"
 #endif
 
+#if defined(ENABLE_MEMORY_PRESSURE_BRIDGE)
+#include "cobalt/browser/memory_pressure_bridge.h"
+#endif
+
 #if BUILDFLAG(IS_LINUX)
 #include "components/os_crypt/sync/key_storage_config_linux.h"
 #include "components/os_crypt/sync/os_crypt.h"
@@ -105,6 +109,8 @@ CobaltBrowserMainParts::CobaltBrowserMainParts(const std::string& deep_link,
                                                bool is_visible)
     : ShellBrowserMainParts(deep_link, is_visible) {}
 
+CobaltBrowserMainParts::~CobaltBrowserMainParts() = default;
+
 int CobaltBrowserMainParts::PreCreateThreads() {
 #if BUILDFLAG(IS_ANDROIDTV)
   starboard::StarboardBridge::GetInstance()->SetStartupMilestone(17);
@@ -146,6 +152,10 @@ int CobaltBrowserMainParts::PreMainMessageLoopRun() {
                << ". Aborting storage migration.";
     return result;
   }
+
+#if defined(ENABLE_MEMORY_PRESSURE_BRIDGE)
+  memory_pressure_bridge_ = std::make_unique<browser::MemoryPressureBridge>();
+#endif
 
   StartStorageMigration();
 

--- a/cobalt/browser/cobalt_browser_main_parts.h
+++ b/cobalt/browser/cobalt_browser_main_parts.h
@@ -41,6 +41,12 @@ class CobaltMetricsServiceClient;
 class CobaltMetricsServicesManagerClient;
 class GlobalFeatures;
 
+#if defined(ENABLE_MEMORY_PRESSURE_BRIDGE)
+namespace browser {
+class MemoryPressureBridge;
+}
+#endif
+
 // TODO(b/390021478): When CobaltContentBrowserClient stops deriving from
 // ShellContentBrowserClient, this should implement BrowserMainParts.
 class CobaltBrowserMainParts : public content::ShellBrowserMainParts {
@@ -51,7 +57,7 @@ class CobaltBrowserMainParts : public content::ShellBrowserMainParts {
   CobaltBrowserMainParts(const CobaltBrowserMainParts&) = delete;
   CobaltBrowserMainParts& operator=(const CobaltBrowserMainParts&) = delete;
 
-  ~CobaltBrowserMainParts() override = default;
+  ~CobaltBrowserMainParts() override;
 
   // ShellBrowserMainParts overrides.
   int PreCreateThreads() override;
@@ -89,6 +95,10 @@ class CobaltBrowserMainParts : public content::ShellBrowserMainParts {
 
   bool migration_finished_ GUARDED_BY_CONTEXT(sequence_checker_) = false;
   base::OnceClosure pending_task_ GUARDED_BY_CONTEXT(sequence_checker_);
+
+#if defined(ENABLE_MEMORY_PRESSURE_BRIDGE)
+  std::unique_ptr<browser::MemoryPressureBridge> memory_pressure_bridge_;
+#endif
 
   base::WeakPtrFactory<CobaltBrowserMainParts> weak_ptr_factory_{this};
 };

--- a/cobalt/browser/memory_pressure_bridge.cc
+++ b/cobalt/browser/memory_pressure_bridge.cc
@@ -1,0 +1,55 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/memory_pressure_bridge.h"
+
+#include "base/functional/bind.h"
+#include "base/location.h"
+#include "starboard/system.h"
+
+namespace cobalt {
+namespace browser {
+
+MemoryPressureBridge::MemoryPressureBridge() {
+  extension_ = static_cast<const StarboardExtensionMemoryPressureApi*>(
+      SbSystemGetExtension(kStarboardExtensionMemoryPressureName));
+
+  if (extension_) {
+    listener_ = std::make_unique<base::MemoryPressureListener>(
+        FROM_HERE,
+        base::BindRepeating(&MemoryPressureBridge::OnMemoryPressure,
+                            base::Unretained(this)));
+  }
+}
+
+MemoryPressureBridge::~MemoryPressureBridge() = default;
+
+void MemoryPressureBridge::OnMemoryPressure(
+    base::MemoryPressureListener::MemoryPressureLevel level) {
+  if (!extension_) return;
+
+  SbMemoryPressureLevel sb_level = kSbMemoryPressureLevelNone;
+  if (level == base::MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE) {
+    sb_level = kSbMemoryPressureLevelModerate;
+  } else if (level == base::MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL) {
+    sb_level = kSbMemoryPressureLevelCritical;
+  }
+
+  if (sb_level != kSbMemoryPressureLevelNone) {
+    extension_->NotifyMemoryPressure(sb_level);
+  }
+}
+
+}  // namespace browser
+}  // namespace cobalt

--- a/cobalt/browser/memory_pressure_bridge.h
+++ b/cobalt/browser/memory_pressure_bridge.h
@@ -1,0 +1,44 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_BROWSER_MEMORY_PRESSURE_BRIDGE_H_
+#define COBALT_BROWSER_MEMORY_PRESSURE_BRIDGE_H_
+
+#include <memory>
+
+#include "base/memory/memory_pressure_listener.h"
+#include "starboard/extension/memory_pressure.h"
+
+namespace cobalt {
+namespace browser {
+
+class MemoryPressureBridge {
+ public:
+  MemoryPressureBridge();
+  ~MemoryPressureBridge();
+
+  MemoryPressureBridge(const MemoryPressureBridge&) = delete;
+  MemoryPressureBridge& operator=(const MemoryPressureBridge&) = delete;
+
+ private:
+  void OnMemoryPressure(base::MemoryPressureListener::MemoryPressureLevel level);
+
+  std::unique_ptr<base::MemoryPressureListener> listener_;
+  const StarboardExtensionMemoryPressureApi* extension_ = nullptr;
+};
+
+}  // namespace browser
+}  // namespace cobalt
+
+#endif  // COBALT_BROWSER_MEMORY_PRESSURE_BRIDGE_H_

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -163,6 +163,8 @@ static_library("starboard_platform") {
     "egl_swap_buffers.cc",
     "features_extension.cc",
     "features_extension.h",
+    "memory_pressure.cc",
+    "memory_pressure.h",
     "file_internal.cc",
     "file_internal.h",
     "get_home_directory.cc",

--- a/starboard/android/shared/memory_pressure.cc
+++ b/starboard/android/shared/memory_pressure.cc
@@ -1,0 +1,46 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/memory_pressure.h"
+
+#include "starboard/common/memory_pressure_registry.h"
+#include "starboard/extension/memory_pressure.h"
+
+namespace starboard {
+namespace android {
+namespace shared {
+
+namespace {
+
+const uint32_t kMemoryPressureApiVersion = 1u;
+
+void NotifyMemoryPressure(SbMemoryPressureLevel level) {
+  MemoryPressureRegistry::GetInstance()->NotifyMemoryPressure(level);
+}
+
+constexpr StarboardExtensionMemoryPressureApi kMemoryPressureApi = {
+    kStarboardExtensionMemoryPressureName,
+    kMemoryPressureApiVersion,
+    &NotifyMemoryPressure,
+};
+
+}  // namespace
+
+const void* GetMemoryPressureApi() {
+  return &kMemoryPressureApi;
+}
+
+}  // namespace shared
+}  // namespace android
+}  // namespace starboard

--- a/starboard/android/shared/memory_pressure.h
+++ b/starboard/android/shared/memory_pressure.h
@@ -1,0 +1,29 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_ANDROID_SHARED_MEMORY_PRESSURE_H_
+#define STARBOARD_ANDROID_SHARED_MEMORY_PRESSURE_H_
+
+namespace starboard {
+namespace android {
+namespace shared {
+
+// Returns the Starboard MemoryPressure Extension API.
+const void* GetMemoryPressureApi();
+
+}  // namespace shared
+}  // namespace android
+}  // namespace starboard
+
+#endif  // STARBOARD_ANDROID_SHARED_MEMORY_PRESSURE_H_

--- a/starboard/android/shared/system_get_extensions.cc
+++ b/starboard/android/shared/system_get_extensions.cc
@@ -27,9 +27,11 @@
 #include "starboard/android/shared/platform_service.h"
 #include "starboard/android/shared/player_set_max_video_input_size.h"
 #include "starboard/android/shared/player_set_video_surface_view.h"
+#include "starboard/android/shared/memory_pressure.h"
 #include "starboard/android/shared/system_info_api.h"
 #include "starboard/common/string.h"
 #include "starboard/extension/configuration.h"
+#include "starboard/extension/memory_pressure.h"
 #include "starboard/extension/crash_handler.h"
 #include "starboard/extension/experimental/experimental_features.h"
 #include "starboard/extension/features.h"
@@ -89,6 +91,9 @@ const void* SbSystemGetExtension(const char* name) {
   }
   if (strcmp(name, kStarboardExtensionSystemInfoName) == 0) {
     return starboard::GetSystemInfoApi();
+  }
+  if (strcmp(name, kStarboardExtensionMemoryPressureName) == 0) {
+    return starboard::android::shared::GetMemoryPressureApi();
   }
   return NULL;
 }

--- a/starboard/common/BUILD.gn
+++ b/starboard/common/BUILD.gn
@@ -69,6 +69,8 @@ static_library("common") {
     "log.cc",
     "media.cc",
     "media.h",
+    "memory_pressure_registry.cc",
+    "memory_pressure_registry.h",
     "metrics/stats_tracker.cc",
     "metrics/stats_tracker.h",
     "murmurhash2.cc",

--- a/starboard/common/bidirectional_fit_reuse_allocator_test.cc
+++ b/starboard/common/bidirectional_fit_reuse_allocator_test.cc
@@ -528,4 +528,62 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, TieredDecommit) {
   EXPECT_TRUE(found_block4);
 }
 
+TYPED_TEST(BidirectionalFitReuseAllocatorTest, OnMemoryPressure) {
+  const size_t kAlignment = sizeof(void*);
+  this->ResetAllocatorWithDecommitSupport();
+
+  const size_t kSmallSize = 512 * 1024;
+  const size_t kLargeSize = 2 * 1024 * 1024;
+
+  void* small_block = this->allocator_->Allocate(kSmallSize, kAlignment);
+  void* large_block = this->allocator_->Allocate(kLargeSize, kAlignment);
+
+  EXPECT_TRUE(small_block != nullptr);
+  EXPECT_TRUE(large_block != nullptr);
+  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 0);
+
+  this->allocator_->Free(small_block);
+  this->allocator_->Free(large_block);
+
+  // Moderate memory pressure should decommit blocks >= 1MB (large_block).
+  this->allocator_->OnMemoryPressure(kSbMemoryPressureLevelModerate);
+
+  bool found_large_decommit = false;
+  bool found_small_decommit = false;
+
+  for (const auto& decommit : this->mock_fallback_allocator_->decommits) {
+    uint8_t* decommit_ptr = static_cast<uint8_t*>(decommit.memory);
+    size_t decommit_size = decommit.size;
+    uint8_t* ptr_small = static_cast<uint8_t*>(small_block);
+    uint8_t* ptr_large = static_cast<uint8_t*>(large_block);
+
+    if (ptr_large >= decommit_ptr && ptr_large < decommit_ptr + decommit_size) {
+      found_large_decommit = true;
+    }
+    if (ptr_small >= decommit_ptr && ptr_small < decommit_ptr + decommit_size) {
+      found_small_decommit = true;
+    }
+  }
+
+  EXPECT_TRUE(found_large_decommit);
+  EXPECT_FALSE(found_small_decommit);
+
+  this->mock_fallback_allocator_->decommits.clear();
+
+  // Critical memory pressure should decommit all blocks (small_block).
+  this->allocator_->OnMemoryPressure(kSbMemoryPressureLevelCritical);
+
+  found_small_decommit = false;
+  for (const auto& decommit : this->mock_fallback_allocator_->decommits) {
+    uint8_t* decommit_ptr = static_cast<uint8_t*>(decommit.memory);
+    size_t decommit_size = decommit.size;
+    uint8_t* ptr_small = static_cast<uint8_t*>(small_block);
+
+    if (ptr_small >= decommit_ptr && ptr_small < decommit_ptr + decommit_size) {
+      found_small_decommit = true;
+    }
+  }
+  EXPECT_TRUE(found_small_decommit);
+}
+
 }  // namespace starboard

--- a/starboard/common/embedded_metadata_reuse_allocator_base.cc
+++ b/starboard/common/embedded_metadata_reuse_allocator_base.cc
@@ -14,6 +14,8 @@
 
 #include "starboard/common/embedded_metadata_reuse_allocator_base.h"
 
+#include <unistd.h>
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -147,6 +149,8 @@ void* EmbeddedMetadataReuseAllocatorBase::Allocate(size_t size,
                                                    size_t alignment) {
   SB_DCHECK_EQ(sizeof(BlockMetadata) % alignment, 0U);
 
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+
   if (!pending_frees_.empty()) {
     for (auto address_to_free : pending_frees_) {
       bool freed = TryFree(address_to_free);
@@ -205,6 +209,7 @@ void EmbeddedMetadataReuseAllocatorBase::Free(void* memory) {
     return;
   }
 
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
   pending_frees_.push_back(memory);
 
   if (pending_frees_.size() == total_allocated_blocks_) {
@@ -337,6 +342,7 @@ bool EmbeddedMetadataReuseAllocatorBase::TryFree(void* memory) {
     return true;
   }
 
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
   BlockMetadata* metadata = static_cast<BlockMetadata*>(memory) - 1;
 
   if (metadata->signature != this ||
@@ -635,6 +641,35 @@ EmbeddedMetadataReuseAllocatorBase::AddFreeBlock(MemoryBlock block_to_add) {
 void EmbeddedMetadataReuseAllocatorBase::RemoveFreeBlock(
     FreeBlockSet::iterator it) {
   free_blocks_.erase(it);
+}
+
+void EmbeddedMetadataReuseAllocatorBase::FlushPendingFrees() {
+  if (!pending_frees_.empty()) {
+    for (auto address_to_free : pending_frees_) {
+      bool freed = TryFree(address_to_free);
+      SB_DCHECK(freed);
+    }
+    pending_frees_.clear();
+  }
+}
+
+void EmbeddedMetadataReuseAllocatorBase::DecommitFreeBlocks(
+    size_t min_size_to_decommit) {
+  size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+  for (const auto& block : free_blocks_) {
+    if (block.size() >= min_size_to_decommit) {
+      uintptr_t start = reinterpret_cast<uintptr_t>(block.address());
+      uintptr_t end = start + block.size();
+      uintptr_t aligned_start = AlignUp(start, page_size);
+      if (aligned_start < end) {
+        size_t aligned_size = AlignDown(end - aligned_start, page_size);
+        if (aligned_size > 0) {
+          fallback_allocator()->Decommit(reinterpret_cast<void*>(aligned_start),
+                                         aligned_size, /*conservative=*/false);
+        }
+      }
+    }
+  }
 }
 
 }  // namespace starboard

--- a/starboard/common/embedded_metadata_reuse_allocator_base.h
+++ b/starboard/common/embedded_metadata_reuse_allocator_base.h
@@ -147,6 +147,9 @@ class EmbeddedMetadataReuseAllocatorBase : public ReuseAllocatorBase {
                                                FreeBlockSet::iterator end,
                                                bool* allocate_from_front) = 0;
 
+  void FlushPendingFrees() override;
+  void DecommitFreeBlocks(size_t min_size_to_decommit) override;
+
  private:
   // The metadata of an allocated block stored at the very beginning of the
   // block when it's allocated.  It natually maintains a double linked list to

--- a/starboard/common/external_metadata_reuse_allocator_base.cc
+++ b/starboard/common/external_metadata_reuse_allocator_base.cc
@@ -14,6 +14,8 @@
 
 #include "starboard/common/external_metadata_reuse_allocator_base.h"
 
+#include <unistd.h>
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -142,6 +144,7 @@ void* ExternalMetadataReuseAllocatorBase::Allocate(size_t size) {
 
 void* ExternalMetadataReuseAllocatorBase::Allocate(size_t size,
                                                    size_t alignment) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
   size = AlignUp(std::max(size, kMinAlignment), kMinAlignment);
   alignment = AlignUp(std::max<size_t>(alignment, 1), kMinAlignment);
 
@@ -279,6 +282,7 @@ bool ExternalMetadataReuseAllocatorBase::TryFree(void* memory) {
     return true;
   }
 
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
   AllocatedBlockMap::iterator it = allocated_blocks_.find(memory);
   if (it == allocated_blocks_.end()) {
     return false;
@@ -531,6 +535,25 @@ ExternalMetadataReuseAllocatorBase::AddFreeBlock(MemoryBlock block_to_add) {
 void ExternalMetadataReuseAllocatorBase::RemoveFreeBlock(
     FreeBlockSet::iterator it) {
   free_blocks_.erase(it);
+}
+
+void ExternalMetadataReuseAllocatorBase::DecommitFreeBlocks(
+    size_t min_size_to_decommit) {
+  size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+  for (const auto& block : free_blocks_) {
+    if (block.size() >= min_size_to_decommit) {
+      uintptr_t start = reinterpret_cast<uintptr_t>(block.address());
+      uintptr_t end = start + block.size();
+      uintptr_t aligned_start = AlignUp(start, page_size);
+      if (aligned_start < end) {
+        size_t aligned_size = AlignDown(end - aligned_start, page_size);
+        if (aligned_size > 0) {
+          fallback_allocator()->Decommit(reinterpret_cast<void*>(aligned_start),
+                                         aligned_size, /*conservative=*/false);
+        }
+      }
+    }
+  }
 }
 
 }  // namespace starboard

--- a/starboard/common/external_metadata_reuse_allocator_base.h
+++ b/starboard/common/external_metadata_reuse_allocator_base.h
@@ -145,6 +145,8 @@ class ExternalMetadataReuseAllocatorBase : public ReuseAllocatorBase {
                                                FreeBlockSet::iterator end,
                                                bool* allocate_from_front) = 0;
 
+  void DecommitFreeBlocks(size_t min_size_to_decommit) override;
+
  private:
   // Map from pointers we returned to the user, back to memory blocks.
   typedef std::map<void*, MemoryBlock> AllocatedBlockMap;

--- a/starboard/common/memory_pressure_registry.cc
+++ b/starboard/common/memory_pressure_registry.cc
@@ -1,0 +1,49 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/common/memory_pressure_registry.h"
+
+#include <algorithm>
+
+namespace starboard {
+
+// static
+MemoryPressureRegistry* MemoryPressureRegistry::GetInstance() {
+  static MemoryPressureRegistry* instance = new MemoryPressureRegistry();
+  return instance;
+}
+
+void MemoryPressureRegistry::RegisterObserver(
+    MemoryPressureObserver* observer) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  observers_.push_back(observer);
+}
+
+void MemoryPressureRegistry::UnregisterObserver(
+    MemoryPressureObserver* observer) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = std::find(observers_.begin(), observers_.end(), observer);
+  if (it != observers_.end()) {
+    observers_.erase(it);
+  }
+}
+
+void MemoryPressureRegistry::NotifyMemoryPressure(SbMemoryPressureLevel level) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto* observer : observers_) {
+    observer->OnMemoryPressure(level);
+  }
+}
+
+}  // namespace starboard

--- a/starboard/common/memory_pressure_registry.h
+++ b/starboard/common/memory_pressure_registry.h
@@ -1,0 +1,53 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_COMMON_MEMORY_PRESSURE_REGISTRY_H_
+#define STARBOARD_COMMON_MEMORY_PRESSURE_REGISTRY_H_
+
+#include <mutex>
+#include <vector>
+
+#include "starboard/extension/memory_pressure.h"
+
+namespace starboard {
+
+class MemoryPressureObserver {
+ public:
+  virtual ~MemoryPressureObserver() = default;
+  virtual void OnMemoryPressure(SbMemoryPressureLevel level) = 0;
+};
+
+class MemoryPressureRegistry {
+ public:
+  static MemoryPressureRegistry* GetInstance();
+
+  void RegisterObserver(MemoryPressureObserver* observer);
+  void UnregisterObserver(MemoryPressureObserver* observer);
+
+  void NotifyMemoryPressure(SbMemoryPressureLevel level);
+
+ private:
+  MemoryPressureRegistry() = default;
+  ~MemoryPressureRegistry() = default;
+
+  MemoryPressureRegistry(const MemoryPressureRegistry&) = delete;
+  MemoryPressureRegistry& operator=(const MemoryPressureRegistry&) = delete;
+
+  std::mutex mutex_;
+  std::vector<MemoryPressureObserver*> observers_;
+};
+
+}  // namespace starboard
+
+#endif  // STARBOARD_COMMON_MEMORY_PRESSURE_REGISTRY_H_

--- a/starboard/common/reuse_allocator_base.cc
+++ b/starboard/common/reuse_allocator_base.cc
@@ -34,9 +34,11 @@ ReuseAllocatorBase::ReuseAllocatorBase(Allocator* fallback_allocator,
       conservative_decommit_blocks_(conservative_decommit_blocks),
       aggressive_decommit_on_suspend_(aggressive_decommit_on_suspend) {
   SB_DCHECK(fallback_allocator_);
+  MemoryPressureRegistry::GetInstance()->RegisterObserver(this);
 }
 
 ReuseAllocatorBase::~ReuseAllocatorBase() {
+  MemoryPressureRegistry::GetInstance()->UnregisterObserver(this);
   for (const auto& fallback_allocation : fallback_allocations_) {
     fallback_allocator_->Free(fallback_allocation.address);
   }
@@ -149,6 +151,55 @@ void ReuseAllocatorBase::TryToDecommitOneBlock() {
       }
     }
     has_pending_decommits_ = false;
+  }
+}
+
+void ReuseAllocatorBase::OnMemoryPressure(SbMemoryPressureLevel level) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  FlushPendingFrees();
+
+  size_t min_size = 0;
+  bool decommit_retained = false;
+  if (level == kSbMemoryPressureLevelModerate) {
+    min_size = 1024 * 1024;  // 1MB
+    decommit_retained = false;
+  } else if (level == kSbMemoryPressureLevelCritical) {
+    min_size = 0;
+    decommit_retained = true;
+  } else {
+    return;
+  }
+
+  DecommitFreeBlocks(min_size);
+
+  for (auto& fallback_block : fallback_allocations_) {
+    if (fallback_block.size >= min_size) {
+      if (fallback_block.state == kIdlePendingDecommit) {
+        fallback_allocator_->Decommit(fallback_block.address,
+                                      fallback_block.size,
+                                      /*conservative=*/false);
+        fallback_block.state = kIdleDecommitted;
+      } else if (fallback_block.state == kIdlePendingFree) {
+        fallback_allocator_->Decommit(fallback_block.address,
+                                      fallback_block.size,
+                                      /*conservative=*/true);
+        fallback_block.state = kIdleFreed;
+      } else if (decommit_retained && fallback_block.state == kIdleRetained) {
+        fallback_allocator_->Decommit(fallback_block.address,
+                                      fallback_block.size,
+                                      /*conservative=*/false);
+        fallback_block.state = kIdleDecommitted;
+      }
+    }
+  }
+
+  has_pending_decommits_ = false;
+  for (const auto& fallback_block : fallback_allocations_) {
+    if (fallback_block.state == kIdlePendingDecommit ||
+        fallback_block.state == kIdlePendingFree) {
+      has_pending_decommits_ = true;
+      break;
+    }
   }
 }
 

--- a/starboard/common/reuse_allocator_base.h
+++ b/starboard/common/reuse_allocator_base.h
@@ -17,10 +17,12 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <utility>
 #include <vector>
 
 #include "starboard/common/allocator.h"
+#include "starboard/common/memory_pressure_registry.h"
 #include "starboard/configuration.h"
 
 namespace starboard {
@@ -37,7 +39,7 @@ namespace starboard {
 //
 // Threading model: Not thread-safe. External synchronization is required when
 // accessing or allocating memory concurrently across multiple threads.
-class ReuseAllocatorBase : public Allocator {
+class ReuseAllocatorBase : public Allocator, public MemoryPressureObserver {
  public:
   // Allocator methods.
   size_t GetCapacity() const override { return capacity_; }
@@ -45,6 +47,9 @@ class ReuseAllocatorBase : public Allocator {
   // Immediately decommit all remaining decommitable blocks (e.g. on app
   // suspend).
   void DecommitAllDecommitableBlocks();
+
+  // MemoryPressureObserver implementation.
+  void OnMemoryPressure(SbMemoryPressureLevel level) override;
 
  protected:
   ReuseAllocatorBase(Allocator* fallback_allocator,
@@ -76,6 +81,14 @@ class ReuseAllocatorBase : public Allocator {
 
   // Step counter to amortize decommits across sequential active allocations.
   void TryToDecommitOneBlock();
+
+ protected:
+  Allocator* fallback_allocator() const { return fallback_allocator_; }
+
+  virtual void FlushPendingFrees() {}
+  virtual void DecommitFreeBlocks(size_t min_size_to_decommit) {}
+
+  mutable std::recursive_mutex mutex_;
 
   // Enumerates fallback backing allocations. Templated to allow zero-cost
   // compiler inlining for capturing lambdas and avoid std::function overhead.

--- a/starboard/extension/memory_pressure.h
+++ b/starboard/extension/memory_pressure.h
@@ -1,0 +1,51 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_EXTENSION_MEMORY_PRESSURE_H_
+#define STARBOARD_EXTENSION_MEMORY_PRESSURE_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define kStarboardExtensionMemoryPressureName \
+  "dev.starboard.extension.MemoryPressure"
+
+typedef enum SbMemoryPressureLevel {
+  kSbMemoryPressureLevelNone = 0,
+  kSbMemoryPressureLevelModerate = 1,
+  kSbMemoryPressureLevelCritical = 2,
+} SbMemoryPressureLevel;
+
+typedef struct StarboardExtensionMemoryPressureApi {
+  // Name should be the string |kStarboardExtensionMemoryPressureName|.
+  // This helps to validate that the extension API is correct.
+  const char* name;
+
+  // This specifies the version of the API that is implemented.
+  uint32_t version;
+
+  // The fields below this point were added in version 1 or later.
+
+  // Notify the platform of memory pressure.
+  void (*NotifyMemoryPressure)(SbMemoryPressureLevel level);
+} StarboardExtensionMemoryPressureApi;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // STARBOARD_EXTENSION_MEMORY_PRESSURE_H_


### PR DESCRIPTION
This PR implements the Android `onTrimMemory` bridge and integrates it with the Starboard allocator as per the spec.

### Changes:
1.  **Android `onTrimMemory` Bridge**:
    *   Introduced `MemoryPressure` Starboard extension to propagate memory pressure events from the platform.
    *   Implemented the extension for Android, bridging `onTrimMemory` calls from Java to Starboard `MemoryPressureRegistry`.
2.  **Cobalt `MemoryPressureBridge`**:
    *   Created `MemoryPressureBridge` in Cobalt browser to listen to `base::MemoryPressureListener` and propagate to Starboard `MemoryPressureRegistry`.
3.  **Starboard Allocator Integration**:
    *   Registered `ReuseAllocatorBase` as an observer of `MemoryPressureRegistry`.
    *   Implemented `OnMemoryPressure` in `ReuseAllocatorBase` to decommit free blocks and idle fallback blocks on Moderate (>=1MB) and Critical (all) memory pressure.
4.  **Testing**:
    *   Added unit tests in `BidirectionalFitReuseAllocatorTest` to verify memory pressure handling.
    *   Verified the build and ran tests successfully on Linux.