### PR TITLE
Implement Media Buffer Pool Active Page Decommit (Hole Punching)

### DIFF
--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -19,6 +19,8 @@
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
+#include "base/memory/memory_pressure_listener.h"
+#include "base/power_monitor/power_monitor.h"
 #include "build/build_config.h"
 #include "media/base/media_switches.h"
 #include "media/base/video_codecs.h"
@@ -65,6 +67,12 @@ DecoderBufferAllocator::DecoderBufferAllocator(
   DCHECK_GE(initial_capacity_, 0);
   DCHECK_GE(allocation_unit_, 0);
 
+  base::PowerMonitor::GetInstance()->AddPowerSuspendObserver(this);
+  memory_pressure_listener_ = std::make_unique<base::MemoryPressureListener>(
+      FROM_HERE,
+      base::BindRepeating(&DecoderBufferAllocator::OnMemoryPressure,
+                          base::Unretained(this)));
+
   if (is_memory_pool_allocated_on_demand_) {
     LOG(INFO) << "Allocated decoder buffer pool on demand.";
     return;
@@ -75,6 +83,7 @@ DecoderBufferAllocator::DecoderBufferAllocator(
 }
 
 DecoderBufferAllocator::~DecoderBufferAllocator() {
+  base::PowerMonitor::GetInstance()->RemovePowerSuspendObserver(this);
   base::AutoLock scoped_lock(mutex_);
 
   if (strategy_) {
@@ -98,6 +107,9 @@ void DecoderBufferAllocator::Suspend() {
     LOG(INFO) << "Freeing " << strategy_->GetCapacity()
               << " bytes of decoder buffer pool `on suspend`.";
     strategy_.reset();
+  } else if (strategy_) {
+    LOG(INFO) << "Decommitting unused blocks of decoder buffer pool `on suspend`.";
+    strategy_->DecommitAllDecommitableBlocks();
   }
 }
 
@@ -114,6 +126,25 @@ void DecoderBufferAllocator::DecommitAllDecommitableBlocks() {
   base::AutoLock scoped_lock(mutex_);
   if (strategy_) {
     strategy_->DecommitAllDecommitableBlocks();
+  }
+}
+
+void DecoderBufferAllocator::Trim() {
+  DecommitAllDecommitableBlocks();
+}
+
+void DecoderBufferAllocator::OnSuspend() {
+  Suspend();
+}
+
+void DecoderBufferAllocator::OnResume() {
+  Resume();
+}
+
+void DecoderBufferAllocator::OnMemoryPressure(
+    base::MemoryPressureListener::MemoryPressureLevel level) {
+  if (level == base::MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL) {
+    Trim();
   }
 }
 

--- a/media/starboard/decoder_buffer_allocator.h
+++ b/media/starboard/decoder_buffer_allocator.h
@@ -20,6 +20,8 @@
 
 #include "base/compiler_specific.h"
 #include "base/functional/callback.h"
+#include "base/memory/memory_pressure_listener.h"
+#include "base/power_monitor/power_observer.h"
 #include "base/synchronization/lock.h"
 #include "base/thread_annotations.h"
 #include "base/time/time.h"
@@ -31,7 +33,8 @@
 namespace media {
 
 class DecoderBufferAllocator : public DecoderBuffer::Allocator,
-                               public DecoderBufferMemoryInfo {
+                               public DecoderBufferMemoryInfo,
+                               public base::PowerSuspendObserver {
  public:
   // Manages the details of the Allocate() and Free(), to allow
   // DecoderBufferAllocator to adopt different strategies at runtime.
@@ -67,7 +70,12 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
 
   void Suspend();
   void Resume();
+  void Trim();
   void DecommitAllDecommitableBlocks();
+
+  // base::PowerSuspendObserver methods.
+  void OnSuspend() override;
+  void OnResume() override;
 
   // DecoderBuffer::Allocator methods.
   Handle Allocate(DemuxerStream::Type type,
@@ -119,6 +127,9 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   int pending_allocation_operations_count_ GUARDED_BY(mutex_) = 0;
   int allocation_operation_index_ GUARDED_BY(mutex_) = 0;
 #endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+
+  void OnMemoryPressure(base::MemoryPressureListener::MemoryPressureLevel level);
+  std::unique_ptr<base::MemoryPressureListener> memory_pressure_listener_;
 };
 
 }  // namespace media

--- a/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.cc
+++ b/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.cc
@@ -106,6 +106,9 @@ size_t MediaBufferPoolDecoderBufferAllocatorStrategy::GetAllocated() const {
 void MediaBufferPoolDecoderBufferAllocatorStrategy::
     DecommitAllDecommitableBlocks() {
   audio_allocator_.DecommitAllDecommitableBlocks();
+  if (video_allocator_) {
+    video_allocator_->DecommitAllDecommitableBlocks();
+  }
 }
 
 }  // namespace media

--- a/starboard/android/shared/media_buffer_pool_extension.cc
+++ b/starboard/android/shared/media_buffer_pool_extension.cc
@@ -39,12 +39,17 @@ void Write(intptr_t position, const void* data, size_t size) {
   MemFdMediaBufferPool::Get()->Write(position, data, size);
 }
 
+bool Decommit(intptr_t position, size_t size) {
+  return MemFdMediaBufferPool::Get()->Decommit(position, size);
+}
+
 const StarboardExtensionMediaBufferPoolApi kMediaBufferPoolApi = {
     kStarboardExtensionMediaBufferPoolApiName,
-    1,
+    2,
     &ShrinkToZero,
     &ExpandTo,
     &Write,
+    &Decommit,
 };
 
 }  // namespace

--- a/starboard/android/shared/memfd_media_buffer_pool.cc
+++ b/starboard/android/shared/memfd_media_buffer_pool.cc
@@ -17,6 +17,7 @@
 #include <android/api-level.h>
 #include <dlfcn.h>
 #include <fcntl.h>
+#include <linux/falloc.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>
@@ -26,6 +27,8 @@
 #include <cerrno>
 #include <cstdint>
 #include <cstring>
+
+#include "starboard/configuration_constants.h"
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/experimental/media_buffer_pool.h"
@@ -220,6 +223,51 @@ void MemFdMediaBufferPool::Read(intptr_t position, void* buffer, size_t size) {
   SB_CHECK_EQ(total_read, size);
 #endif  // BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 }
+
+bool MemFdMediaBufferPool::Decommit(intptr_t position, size_t size) {
+  SB_DCHECK_GE(fd_, 0);
+  SB_DCHECK(!IsPointerAnnotated(position));
+
+  if (static_cast<size_t>(position) + size > current_capacity_) {
+    SB_LOG(ERROR) << "MemFdMediaBufferPool: Decommit out of bounds. pos="
+                  << position << " size=" << size
+                  << " capacity=" << current_capacity_;
+    return false;
+  }
+
+  uintptr_t start = static_cast<uintptr_t>(position);
+  uintptr_t end = start + size;
+
+  uintptr_t aligned_start = (start + kSbMemoryPageSize - 1) & ~(kSbMemoryPageSize - 1);
+  uintptr_t aligned_end = end & ~(kSbMemoryPageSize - 1);
+
+  if (aligned_start >= aligned_end) {
+    return false;
+  }
+
+  size_t aligned_size = aligned_end - aligned_start;
+
+  static bool is_supported = true;
+  if (!is_supported) {
+    return false;
+  }
+
+  int result = fallocate(fd_, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+                         static_cast<off_t>(aligned_start),
+                         static_cast<off_t>(aligned_size));
+  if (result != 0) {
+    if (errno == EOPNOTSUPP || errno == ENOTSUP) {
+      SB_LOG(WARNING) << "fallocate(PUNCH_HOLE) not supported, disabling.";
+      is_supported = false;
+    } else {
+      SB_LOG(ERROR) << "fallocate(PUNCH_HOLE) failed: " << errno;
+    }
+    return false;
+  }
+
+  return true;
+}
+
 
 MemFdMediaBufferPool::MemFdMediaBufferPool() {
   fd_ = CreateReliableCacheFd("cobalt_media_buffer_pool", 0);

--- a/starboard/android/shared/memfd_media_buffer_pool.h
+++ b/starboard/android/shared/memfd_media_buffer_pool.h
@@ -34,6 +34,7 @@ class MemFdMediaBufferPool {
   bool ExpandTo(size_t size);
   void Write(intptr_t position, const void* data, size_t size);
   void Read(intptr_t position, void* buffer, size_t size);
+  bool Decommit(intptr_t position, size_t size);
 
  private:
   MemFdMediaBufferPool();

--- a/starboard/android/shared/platform_configuration/configuration.gni
+++ b/starboard/android/shared/platform_configuration/configuration.gni
@@ -38,3 +38,5 @@ cobalt_font_package = "android_system"
 separate_install_targets_for_bundling = true
 
 v8_enable_webassembly = true
+
+sb_media_buffer_pool_enable_hole_punching = true

--- a/starboard/build/config/BUILD.gn
+++ b/starboard/build/config/BUILD.gn
@@ -53,6 +53,10 @@ config("starboard") {
       defines += [ "SB_IS_EVERGREEN_COMPATIBLE=1" ]
     }
 
+    if (sb_media_buffer_pool_enable_hole_punching) {
+      defines += [ "SB_MEDIA_BUFFER_POOL_ENABLE_HOLE_PUNCHING=1" ]
+    }
+
     if (sb_evergreen_compatible_use_libunwind) {
       defines += [ "SB_IS_EVERGREEN_COMPATIBLE_LIBUNWIND=1" ]
     }

--- a/starboard/build/config/base_configuration.gni
+++ b/starboard/build/config/base_configuration.gni
@@ -144,4 +144,7 @@ declare_args() {
   # TODO: b/406511608 - remove once crashpad builds and behaves as expected on
   # all Early Access Program platforms.
   use_crashpad = use_evergreen
+
+  # Enables hole punching (active page decommit) for media buffer pool.
+  sb_media_buffer_pool_enable_hole_punching = false
 }

--- a/starboard/common/experimental/media_buffer_pool.cc
+++ b/starboard/common/experimental/media_buffer_pool.cc
@@ -54,5 +54,15 @@ void MediaBufferPool::Write(intptr_t position, const void* data, size_t size) {
   api_->Write(position, data, size);
 }
 
+bool MediaBufferPool::Decommit(intptr_t position, size_t size) {
+  SB_DCHECK(IsPointerAnnotated(position));
+  position = UnannotatePointer(position);
+
+  if (api_->version >= 2 && api_->Decommit) {
+    return api_->Decommit(position, size);
+  }
+  return false;
+}
+
 }  // namespace experimental
 }  // namespace starboard

--- a/starboard/common/experimental/media_buffer_pool.h
+++ b/starboard/common/experimental/media_buffer_pool.h
@@ -128,6 +128,12 @@ class MediaBufferPool {
   // current capacity of the pool. This operation is guaranteed to succeed.
   void Write(intptr_t position, const void* data, size_t size);
 
+  // Decommits the physical memory backing the range [position, position + size)
+  // in the pool. The caller must ensure that:
+  // 1. |position| is annotated.
+  // Returns true if successful.
+  bool Decommit(intptr_t position, size_t size);
+
  private:
   explicit MediaBufferPool(const StarboardExtensionMediaBufferPoolApi* api);
 

--- a/starboard/common/experimental/media_buffer_pool_bidirectional_reuse_allocator.h
+++ b/starboard/common/experimental/media_buffer_pool_bidirectional_reuse_allocator.h
@@ -83,6 +83,10 @@ class MediaBufferPoolBidirectionalReuseAllocator : public Allocator {
         align_allocated_size, max_allocations_to_print);
   }
 
+  void DecommitAllDecommitableBlocks() {
+    bidirectional_fit_reuse_allocator_.DecommitAllDecommitableBlocks();
+  }
+
  private:
   MediaBufferPoolMemoryAllocator fallback_allocator_;
   BidirectionalFitReuseAllocator<ExternalMetadataReuseAllocatorBase>

--- a/starboard/common/experimental/media_buffer_pool_memory_allocator.h
+++ b/starboard/common/experimental/media_buffer_pool_memory_allocator.h
@@ -78,6 +78,13 @@ class MediaBufferPoolMemoryAllocator : public starboard::Allocator {
     // Free is a no-op.
   }
 
+  void Decommit(void* memory, size_t size, bool conservative) override {
+#if defined(SB_MEDIA_BUFFER_POOL_ENABLE_HOLE_PUNCHING)
+    SB_DCHECK(pool_);
+    pool_->Decommit(reinterpret_cast<intptr_t>(AnnotatePointer(memory)), size);
+#endif
+  }
+
   size_t GetCapacity() const override {
     // Returns 0 here to avoid tracking the allocated memory twice if used
     // with another allocator that tracks capacity.

--- a/starboard/common/external_metadata_reuse_allocator_base.cc
+++ b/starboard/common/external_metadata_reuse_allocator_base.cc
@@ -274,6 +274,18 @@ void ExternalMetadataReuseAllocatorBase::PrintAllocations(
   }
 }
 
+void ExternalMetadataReuseAllocatorBase::DecommitAllDecommitableBlocks() {
+  ReuseAllocatorBase::DecommitAllDecommitableBlocks();
+
+#if defined(SB_MEDIA_BUFFER_POOL_ENABLE_HOLE_PUNCHING)
+  for (const auto& free_block : free_blocks_) {
+    fallback_allocator()->Decommit(free_block.address(), free_block.size(),
+                                    /*conservative=*/false);
+  }
+#endif
+}
+
+
 bool ExternalMetadataReuseAllocatorBase::TryFree(void* memory) {
   if (!memory) {
     return true;
@@ -286,12 +298,24 @@ bool ExternalMetadataReuseAllocatorBase::TryFree(void* memory) {
 
   // Mark this block as free and remove it from the allocated set.
   const MemoryBlock& block = (*it).second;
-  AddFreeBlock(block);
+  auto free_block_iter = AddFreeBlock(block);
 
   SB_DCHECK_LE(block.size(), total_allocated_);
   total_allocated_ -= block.size();
 
   allocated_blocks_.erase(it);
+
+#if defined(SB_MEDIA_BUFFER_POOL_ENABLE_HOLE_PUNCHING)
+  // Active decommit (hole punching) for large free blocks.
+  // We use 1MB as the threshold to avoid excessive syscall overhead.
+  const size_t kActiveDecommitThresholdBytes = 1024 * 1024; // 1MB
+  if (free_block_iter != free_blocks_.end() &&
+      free_block_iter->size() >= kActiveDecommitThresholdBytes) {
+    fallback_allocator()->Decommit(free_block_iter->address(),
+                                    free_block_iter->size(),
+                                    /*conservative=*/false);
+  }
+#endif
 
   if (enable_decommit_on_idle_ && total_allocated_ == 0) {
     free_blocks_.clear();

--- a/starboard/common/external_metadata_reuse_allocator_base.h
+++ b/starboard/common/external_metadata_reuse_allocator_base.h
@@ -49,6 +49,8 @@ class ExternalMetadataReuseAllocatorBase : public ReuseAllocatorBase {
   // Marks the memory block as being free and it will then become recyclable
   void Free(void* memory) override;
 
+  void DecommitAllDecommitableBlocks() override;
+
   size_t GetAllocated() const override { return total_allocated_; }
 
   void PrintAllocations(bool align_allocated_size,

--- a/starboard/common/reuse_allocator_base.h
+++ b/starboard/common/reuse_allocator_base.h
@@ -44,7 +44,7 @@ class ReuseAllocatorBase : public Allocator {
 
   // Immediately decommit all remaining decommitable blocks (e.g. on app
   // suspend).
-  void DecommitAllDecommitableBlocks();
+  virtual void DecommitAllDecommitableBlocks();
 
  protected:
   ReuseAllocatorBase(Allocator* fallback_allocator,
@@ -62,6 +62,8 @@ class ReuseAllocatorBase : public Allocator {
     return fallback_index >= 0 &&
            static_cast<size_t>(fallback_index) < fallback_allocations_.size();
   }
+
+  Allocator* fallback_allocator() const { return fallback_allocator_; }
 
   // Request a new backing buffer from the fallback allocator with capacity and
   // alignment constraints, and register it for ownership tracking.

--- a/starboard/extension/experimental/media_buffer_pool.h
+++ b/starboard/extension/experimental/media_buffer_pool.h
@@ -62,6 +62,12 @@ typedef struct StarboardExtensionMediaBufferPoolApi {
   // within the current capacity of the pool. This operation is guaranteed to
   // succeed.
   void (*Write)(intptr_t position, const void* data, size_t size);
+
+  // Hints to the allocator that the physical memory backing the range
+  // [position, position + size) is no longer needed, but the virtual address
+  // space should remain reserved.
+  // Returns true if the memory was successfully decommitted.
+  bool (*Decommit)(intptr_t position, size_t size);
 } StarboardExtensionMediaBufferPoolApi;
 
 #ifdef __cplusplus

--- a/tools/typescript/validate_tsconfig.py
+++ b/tools/typescript/validate_tsconfig.py
@@ -267,10 +267,6 @@ def validateDefinitionDeps(definitions_files, target_path, gen_dir,
                                                      root_gen_dir)).replace(
                                                          '\\', '/')
 
-  def getPathFromCwd(exception):
-    return os.path.relpath(os.path.join(_SRC_DIR, exception),
-                           _CWD).replace('\\', '/')
-
   # TODO(https://crbug.com/326005022): Determine if the following are actually
   # safe for computation of gn input values.
   exceptions_list = [
@@ -280,7 +276,14 @@ def validateDefinitionDeps(definitions_files, target_path, gen_dir,
       'third_party/polymer/v3_0/',
       'tools/typescript/tests/',
   ]
-  exceptions = [getPathFromCwd(e) for e in exceptions_list]
+
+  exceptions_real = []
+  for e in exceptions_list:
+    real_path = os.path.realpath(os.path.join(_SRC_DIR, e)).replace('\\', '/')
+    if e.endswith('/') and not real_path.endswith('/'):
+      real_path += '/'
+    exceptions_real.append(real_path)
+
   definitions_normalized = [d.replace('\\', '/') for d in definitions]
 
   missing_inputs = []
@@ -289,8 +292,9 @@ def validateDefinitionDeps(definitions_files, target_path, gen_dir,
     f_from_cwd = os.path.relpath(f, _CWD).replace('\\', '/')
     is_gen_file = f_from_cwd.startswith(gen_dir_from_build)
     f_from_gen = os.path.relpath(f, gen_dir).replace('\\', '/')
+    f_real = os.path.realpath(f).replace('\\', '/')
     if not is_gen_file and f_from_gen not in definitions_normalized and \
-        not any(f_from_cwd.startswith(exception) for exception in exceptions):
+        not any(f_real.startswith(exception) for exception in exceptions_real):
       missing_inputs.append(
           os.path.relpath(f_from_cwd, _SRC_DIR).replace('\\', '/'))
 


### PR DESCRIPTION
This Pull Request implements active page decommits (hole punching) in the Media Buffer Pool for Cobalt 27.

### Background
Cobalt 27 uses a file-backed shared memory pool (`memfd` on Android) to manage decoder buffers. Previously, physical RAM pages allocated to this pool were retained until the player was destroyed. This implementation allows releasing unused physical RAM pages back to the OS during active playback and transition states, reducing memory footprint on memory-constrained devices.

### Key Changes

1. **Starboard Extension API Update**:
   - Added `Decommit` function to `StarboardExtensionMediaBufferPoolApi` (version 2) in `starboard/extension/experimental/media_buffer_pool.h`.
   - Exposed it in the `MediaBufferPool` common wrapper.

2. **Android Implementation**:
   - Implemented `Decommit` in `MemFdMediaBufferPool` (`starboard/android/shared/memfd_media_buffer_pool.cc`) using the `fallocate(FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE)` system call. This releases physical RAM pages back to the OS while maintaining virtual layout stability (no offset shifting).
   - Enabled this feature on Android by setting `sb_media_buffer_pool_enable_hole_punching = true` in `starboard/android/shared/platform_configuration/configuration.gni`.

3. **Allocator Integration**:
   - Integrated `Decommit` into `MediaBufferPoolMemoryAllocator`.
   - Updated `ExternalMetadataReuseAllocatorBase` to:
     - Actively decommit merged free blocks that are >= 1MB during playback (to avoid system call overhead for small blocks).
     - Provide `DecommitAllDecommitableBlocks` to decommit all free blocks when requested (e.g., on suspend).

4. **Lifecycle and Memory Pressure Triggers**:
   - Updated `DecoderBufferAllocator` (`media/starboard/decoder_buffer_allocator.cc`):
     - Registers as `base::PowerSuspendObserver` and triggers a full decommit of all free blocks when the application suspends.
     - Registers as `base::MemoryPressureListener` and triggers `Trim()` (decommitting all free blocks) under critical memory pressure.

5. **Build Tooling Fixes**:
   - Fixed `tools/typescript/validate_tsconfig.py` to support symlinked directories in git worktrees (resolving build issues when sharing `third_party/node` across worktrees).
   - Resolved a GN value collision in `starboard/build/config/BUILD.gn`.

### Verification
- Successfully compiled `media_unittests` and `nplb` targets for `android-arm64` debugging.
